### PR TITLE
Lock nginx version to 1.13 in nginx production Dockerfile.

### DIFF
--- a/nginx/production/Dockerfile
+++ b/nginx/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.13
 
 RUN mkdir -p /etc/nginx/ssl/
 RUN apt-get update --fix-missing


### PR DESCRIPTION
Temporary fix for #16 