### PR TITLE
Bump nginx

### DIFF
--- a/nginx/production/Dockerfile
+++ b/nginx/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13
+FROM nginx:1.25
 
 RUN mkdir -p /etc/nginx/ssl/
 RUN apt-get update --fix-missing

--- a/nginx/production/conf.d/default.conf
+++ b/nginx/production/conf.d/default.conf
@@ -15,11 +15,10 @@ server {
     # Disable buffering so large file downloads don't get cut off
     proxy_max_temp_file_size 0;
 
-    listen 443; ## listen for ipv4; this line is default and implied
+    listen 443 ssl; ## listen for ipv4; this line is default and implied
     #listen [::]:80 default ipv6only=on; ## listen for ipv6
 
     add_header Strict-Transport-Security "max-age=17280000";
-    ssl on;
     # *** Update path ***
     ssl_certificate /etc/ssl/certs/autograder.io.cert;
     # *** Update path ***


### PR DESCRIPTION
- Bump production nginx to 1.25
- Remove "ssl on" in nginx config, replace with "listen 443 ssl"

Fixes #21 
